### PR TITLE
Switch from mitchellh/mapstructure to go-viper/mapstructure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Switch from mitchellh/mapstructure to go-viper/mapstructure (#69).
+
 ## [v0.3.0] - 11/17/2023
 
 ### Changed

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/ktong/konf
 
 go 1.21
 
-require github.com/mitchellh/mapstructure v1.5.0
+require github.com/go-viper/mapstructure/v2 v2.0.0-alpha.1

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
-github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/go-viper/mapstructure/v2 v2.0.0-alpha.1 h1:TQcrn6Wq+sKGkpyPvppOz99zsMBaUOKXq6HSv655U1c=
+github.com/go-viper/mapstructure/v2 v2.0.0-alpha.1/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=

--- a/option.go
+++ b/option.go
@@ -3,7 +3,7 @@
 
 package konf
 
-import "github.com/mitchellh/mapstructure"
+import "github.com/go-viper/mapstructure/v2"
 
 // WithDelimiter provides the delimiter used when specifying config paths.
 // The delimiter is used to separate keys in the path.


### PR DESCRIPTION
Reference: https://github.com/mitchellh/mapstructure/issues/349#issuecomment-1860372162

mitchellh stops the maintenance for [mapstructure](https://github.com/mitchellh/mapstructure) and other https://github.com/mitchellh/mapstructure/issues/349#issuecomment-1859202291.

The mapstructure project is already forked by viper project, since they have a strong dependency against it.

https://github.com/go-viper/mapstructure